### PR TITLE
setup install fails with container must be Glassfish or JBoss

### DIFF
--- a/src/main/config/setup.properties.example
+++ b/src/main/config/setup.properties.example
@@ -1,11 +1,11 @@
 # Glassfish
 secure         = true
-container      = glassfish
+container      = Glassfish
 home           = /home/fisher/pf/glassfish4
 port           = 4848
 
 # WildFly
 !secure         = false
-!container      = wildfly
+!container      = JBoss
 !home           = /home/fisher/pf/wildfly
 !port           = 9990

--- a/src/site/xdoc/installation.xml.vm
+++ b/src/site/xdoc/installation.xml.vm
@@ -48,7 +48,7 @@
 		<subsection name="The setup.properties file">
 		<dl>
 			<dt>container</dt>
-			<dd>May be either glassfish or wildfly - though only glassfish
+			<dd>May be either Glassfish or JBoss - though only glassfish
 				is working fully at the moment.</dd>
 			<dt>home</dt>
 			<dd>is the top level of the container installation. For


### PR DESCRIPTION
When using the provided setup.properties.example, setup install fails with the following error message:
```
$ ./setup install
container must be Glassfish or JBoss 
Setup is not complete
```
After setting container to Glassfish as suggested, installing the component works. So, setup.properties.example and the documentation in site should be updated.