### PR TITLE
Add IP address in debug log.

### DIFF
--- a/src/main/java/org/icatproject/authn_anon/ANON_Authenticator.java
+++ b/src/main/java/org/icatproject/authn_anon/ANON_Authenticator.java
@@ -79,7 +79,7 @@ public class ANON_Authenticator {
 			}
 		}
 
-		logger.debug("Login request");
+		logger.debug("Login request from {}", (ip != null ? ip : "?"));
 
 		if (addressChecker != null) {
 			try {


### PR DESCRIPTION
In deployments with non-trivial network configuration (e.g. proxies), it is not always obvious, which IP address the authentication plugin will see the request coming from. But this may be important to configure the `ip` attribute in `run.properties`. In such situations it may be useful if the IP address is logged in the debug output.

See also icatproject/authn.simple#1.