### PR TITLE
Update dependencies that have security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,14 +96,14 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.4</version>
+			<version>4.3.6</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
-			<version>4.3.4</version>
+			<version>4.3.6</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
`org.apache.httpcomponents:httpclient` has a potential security vulnerability (see https://nvd.nist.gov/vuln/detail/CVE-2015-5262) and so the version has been updated to the patched version. I also updated the version of the other `org.apache.httpcomponents` dependency so that their version numbers match.