### PR TITLE
Change ICAT Ansible host references to use underscores

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: underscore_changes
+          ref: master
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: fix_warnings_#23
+          ref: underscore_changes
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
 
@@ -55,8 +55,8 @@ jobs:
           sed -i -e "s/^payara_user: \"glassfish\"/payara_user: \"runner\"/" icat-ansible/group_vars/all/vars.yml
       - name: Add Ansible Role
         run: |
-          sed -i "/- role: icat-server$/a\
-          \    - role: dev-common" icat-ansible/icatdb_minimal_hosts.yml
+          sed -i "/- role: icat_server$/a\
+          \    - role: dev_common" icat-ansible/icatdb_minimal_hosts.yml
 
       # Force hostname to localhost - bug fix for previous ICAT Ansible issues on Actions
       - name: Change hostname to localhost

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,12 +39,13 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
+          ref: fix_warnings_#23
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
 
       # Prep for running the playbook
       - name: Create Hosts File
-        run: echo -e "[icatdb-minimal-hosts]\nlocalhost ansible_connection=local" > icat-ansible/hosts
+        run: echo -e "[icatdb_minimal_hosts]\nlocalhost ansible_connection=local" > icat-ansible/hosts
       - name: Prepare vault pass
         run: echo -e "icattravispw" > icat-ansible/vault_pass.txt
       - name: Move vault to directory it'll get detected by Ansible
@@ -55,7 +56,7 @@ jobs:
       - name: Add Ansible Role
         run: |
           sed -i "/- role: icat-server$/a\
-          \    - role: dev-common" icat-ansible/icatdb-minimal-hosts.yml
+          \    - role: dev-common" icat-ansible/icatdb_minimal_hosts.yml
 
       # Force hostname to localhost - bug fix for previous ICAT Ansible issues on Actions
       - name: Change hostname to localhost
@@ -64,7 +65,7 @@ jobs:
       # Create local instance of ICAT
       - name: Run ICAT Ansible Playbook
         run: |
-          ansible-playbook icat-ansible/icatdb-minimal-hosts.yml -i icat-ansible/hosts --vault-password-file icat-ansible/vault_pass.txt -vv
+          ansible-playbook icat-ansible/icatdb_minimal_hosts.yml -i icat-ansible/hosts --vault-password-file icat-ansible/vault_pass.txt -vv
 
       # The authn-anon deployed by ansible needs to be undeployed so that the build can run
       - name: Undeploy authn-anon


### PR DESCRIPTION
## Description
A PR on ICAT Ansible (https://github.com/icatproject-contrib/icat-ansible/pull/32) causes breaking changes for this repo's CI. In a sentence, dashes of host names (and its respective host file names) are changed to underscores.

When https://github.com/icatproject-contrib/icat-ansible/pull/32 is merged, the ICAT Ansible branch on the CI needs to be changed back to master. I shall leave it as `fix_warnings_#23` for the time being because the CI won't pass otherwise.

## Testing Instructions
Just check that CI passes.

- [ ] Review code
- [ ] Check GitHub Actions build
